### PR TITLE
feat(reporting): 日報回答からの導入文自動除去機能の追加

### DIFF
--- a/src/perplexity_automator.py
+++ b/src/perplexity_automator.py
@@ -294,6 +294,19 @@ def submit_to_perplexity(prompt_parts):
     if not response:
         return "エラー: クリップボードが空でした。"
     
+    # Clean up response preamble
+    # The template starts with titles like "作業日報 YY-MM-DD" or similar.
+    # We look for the first occurrence of "# 作業日報" or simply "作業日報" to find the start.
+    target_marker = "作業日報"
+    if target_marker in response:
+        start_index = response.find(target_marker)
+        # If there's a '#' before it, include it.
+        if start_index > 0 and response[start_index-1] == "#":
+            start_index -= 1
+        
+        print(f"回答から導入文を検出しました。キーワード '{target_marker}' 以降を抽出します。")
+        response = response[start_index:].strip()
+    
     return response
 
 def submit_to_gemini(prompt, prompt_file_path=None):


### PR DESCRIPTION
## 概要
LLMの回答に含まれる不要な導入文を自動的に除去する機能を追加しました。

## 変更内容
- キーワード「作業日報」を基準に、それより前のテキストを削除する処理を実装。
- Closes #6